### PR TITLE
Input multibeam in instantiating PVPlot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ pvanalysis can do the following things.
 
 * astropy
 * copy
+* corner
 * emcee
 * math
 * matplotlib

--- a/pvanalysis/_pvanalysis.py
+++ b/pvanalysis/_pvanalysis.py
@@ -1029,7 +1029,8 @@ class PVAnalysis():
                         vsys=self.vsys, dist=self.dist,
                         d=self.fitsdata.data,
                         v=self.fitsdata.vaxis, x=self.fitsdata.xaxis,
-                        loglog=loglog, vlim=vlim, xlim=xlim)
+                        loglog=loglog, vlim=vlim, xlim=xlim,
+                        multibeam=self.fitsdata.multibeam)
             cblabel = self.fitsdata.header['BUNIT']
             if Tbcolor: cblabel = r'T$_{\rm b}$ (K)'
             pp.add_color(log=logcolor, Tb=Tbcolor, cblabel=cblabel,


### PR DESCRIPTION
PVPlot in plot_fitresult receives d, v, x directly, rather than through a fits file. So, I added the argument of multibeam=self.fitsdata.multibeam, like d, v, x, to directly input multibeam.