### PR TITLE
Added fix_pin and fix_dp in fit_edgeridge

### DIFF
--- a/example.py
+++ b/example.py
@@ -20,6 +20,8 @@ use_position = True  # cuts along the positional direction
 include_vsys = False  # vsys offset. False means vsys=0.
 include_dp = True  # False means a single power
 include_pin = False  # False means pin=0.5 (Keplerian).
+fix_pin = 0.5  # Fix pin when include_pin is False.
+fix_dp = 0.0  # Fix dp when include_dp is False.
 show_pv = True  # figures will be made regardless of this option.
 show_corner = True  # figures will be made regardless of this option.
 minabserr = 0.1  # minimum absolute errorbar in the unit of bmaj or dv.
@@ -39,6 +41,7 @@ impv.write_edgeridge(outname=outname)
 impv.fit_edgeridge(include_vsys=include_vsys,
                    include_dp=include_dp,
                    include_pin=include_pin,
+                   fix_pin=fix_pin, fix_dp=fix_dp,
                    outname=outname, rangelevel=0.8,
                    show_corner=show_corner)
 impv.output_fitresult()

--- a/pvanalysis/_pvanalysis.py
+++ b/pvanalysis/_pvanalysis.py
@@ -794,6 +794,8 @@ class PVAnalysis():
     def fit_edgeridge(self, include_vsys: bool = False,
                       include_dp: bool = True,
                       include_pin: bool = False,
+                      fix_pin: float = 0.5,
+                      fix_dp: float = 0,
                       outname: str = 'pvanalysis',
                       rangelevel: float = 0.8,
                       show_corner: bool = False) -> dict:
@@ -804,9 +806,13 @@ class PVAnalysis():
             include_vsys : bool
                False means vsys is fixed at 0.
             include_dp : bool
-               False means dp is fixed at 0, i.e., single power law function.
+               False means dp is fixed at fix_dp.
             include_pin : bool
-               False means pin is fixed at 0.5, i.e., the Keplerian law.
+               False means pin is fixed at fix_pin.
+            fix_pin : float
+               pin = fix_pin if include_pix is False. pin = 0.5 means the Keplerian law.
+            fix_dp : float
+               dp = fix_dp if include_dp is False. dp = 0 means a single-power fitting.
             outname : str
                The output corner figures have names of "outname".corner_e.png
                and "outname".corner_r.png.
@@ -848,7 +854,8 @@ class PVAnalysis():
             return -1
 
         labels = np.array(['Rb', 'Vb', 'p_in', 'dp', 'Vsys'])
-        include = [True, include_dp, include_pin, include_dp, include_vsys]
+        include = [True, include_dp or (fix_dp != 0), include_pin,
+                   include_dp, include_vsys]
         labels = labels[include]
         popt_e, popt_r = [np.empty(5), np.empty(5)], [np.empty(5), np.empty(5)]
         minabs = lambda a, i, j: np.min(np.abs(np.r_[a[i], a[j]]))
@@ -857,7 +864,8 @@ class PVAnalysis():
             plim = np.array([
                    [minabs(args, 1, 3), minabs(args, 0, 4), 0.01, 0, -1],
                    [maxabs(args, 1, 3), maxabs(args, 0, 4), 10.0, 10, 1]])
-            q0 = np.array([0, np.sqrt(plim[0][1] * plim[1][1]), 0.5, 0, 0])
+            q0 = np.array([0, np.sqrt(plim[0][1] * plim[1][1]),
+                           fix_pin, fix_dp, 0])
             q0 = np.where(include, np.nan, q0)
             def wpow_r_custom(v, *p):
                 (q := q0 * 1)[np.isnan(q0)] = p


### PR DESCRIPTION
When include_pin / include_dp is False, pin / dp can be fixed an arbitrary value (fix_pin / fix_dp). When include_dp is False and fix_dp is not zero, Vb becomes a free parameter. When include_dp is False and fix_dp is zero, Vb is not a free parameter.