### PR TITLE
nsteps and single-power caution

### DIFF
--- a/pvanalysis/_pvanalysis.py
+++ b/pvanalysis/_pvanalysis.py
@@ -1084,7 +1084,11 @@ class PVAnalysis():
             drb, dvb, dpin, ddp, dvsys = popt[1]
             params = [*popt[0], *popt[1]]
             print(f'R_b   = {rb:.2f} +/- {drb:.2f} au')
+            if ddp == 0:
+                print('!!! Rb is NOT a break (disk) radius in the single-power fitting. !!!')
             print(f'V_b   = {vb:.3f} +/- {dvb:.3f} km/s')
+            if ddp == 0:
+                print('!!! Vb is a middle velocity in the single-power fitting. !!!')
             print(f'p_in  = {pin:.3f} +/- {dpin:.3f}')
             print(f'dp    = {dp:.3f} +/- {ddp:.3f}')
             print(f'v_sys = {self.vsys + vsys:.3f} +/- {dvsys:.3f}')

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ def gauss1d(x, amp, mean, fwhm):
 
 
 def emcee_corner(bounds, log_prob_fn, args=None, nwalkers_per_ndim=16,
-                 nburnin=2000, nsteps=1000, gr_check=False, ndata=1000,
+                 nburnin=2000, nsteps=2000, gr_check=False, ndata=1000,
                  labels=None, rangelevel=0.8, figname=None,
                  show_corner=False, ncore=1, calc_evidence=False):
     ndim = len(bounds[0])


### PR DESCRIPTION
nsteps has been changed from 1000 to 2000 for consistency about the bug of nsteps *= 2.
Cautions added to avoid misunderstanding about Rb and Vb in the single-power law fitting.
